### PR TITLE
update Commenter Secret

### DIFF
--- a/.github/workflows/commenter.yml
+++ b/.github/workflows/commenter.yml
@@ -17,7 +17,7 @@ jobs:
           TEST_SUITE: e2e-test-output
           PROGRESS_FILE: ./artifacts/commenter-progress-flake-bot.yaml
           ARTIFACT: flake-bot-operator-fw-artifact
-          TOKEN: ${{secrets.BOWEN_BOT}}
+          TOKEN: ${{secrets.FLAKE_BOT_SECRET}}
         run: make commenter
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This commit updates the commenter secret. Secretes update can only be tested by opening PR from branches on the upstream repo.